### PR TITLE
Add id and multiverseid query parameters

### DIFF
--- a/src/MtgApiManager.Lib.Test/Service/CardServiceTests.cs
+++ b/src/MtgApiManager.Lib.Test/Service/CardServiceTests.cs
@@ -119,16 +119,16 @@ namespace MtgApiManager.Lib.Test.Service
         [Fact]
         public async Task AllAsync_NoMock_EqualPageSize()
         {
-            const int pageSize = 50;
+            const int PAGE_SIZE = 50;
             var serviceProvider = new MtgServiceProvider();
             var service = serviceProvider.GetCardService();
 
             var result = await service
                 .Where(x => x.Page, 1)
-                .Where(x => x.PageSize, pageSize)
+                .Where(x => x.PageSize, PAGE_SIZE)
                 .AllAsync();
 
-            Assert.Equal(pageSize, result.PagingInfo.PageSize);
+            Assert.Equal(PAGE_SIZE, result.PagingInfo.PageSize);
         }
 
         [Fact]
@@ -535,6 +535,87 @@ namespace MtgApiManager.Lib.Test.Service
                 .WithQueryParams("name", "language");
         }
 
+
+        [Fact]
+        public async Task Where_AddsIdParameter_Success()
+        {
+            const string MULTIPLE_IDS = 
+                "896a92b1-ed29-5daf-bf89-2502224f8f11|516dd7a4-fad8-5eed-bcdb-c05088762303";
+            
+            const string ID_PARAM = "id";
+
+            _mockRateLimit.Setup(x => x.IsTurnedOn).Returns(false);
+
+            _mockHeaderManager.Setup(x => x.Update(It.IsAny<IReadOnlyNameValueList<string>>()));
+            _mockHeaderManager.Setup(x => x.Get<int>(ResponseHeader.TotalCount)).Returns(2000);
+            _mockHeaderManager.Setup(x => x.Get<int>(ResponseHeader.PageSize)).Returns(1000);
+
+            var rootCardList = new RootCardListDto()
+            {
+                Cards = new List<CardDto> { new CardDto() },
+            };
+
+            using var httpTest = new HttpTest();
+            httpTest.RespondWithJson(rootCardList);
+
+            _mockModelMapper.Setup(x => x.MapCard(It.IsAny<CardDto>())).Returns(new Card());
+
+            var service = new CardService(
+                _mockHeaderManager.Object,
+                _mockModelMapper.Object,
+                ApiVersion.V1,
+                _mockRateLimit.Object);
+
+            // act
+            await service
+                .Where(x => x.Id, MULTIPLE_IDS)
+                .AllAsync();
+
+            // assert
+            httpTest
+                .ShouldHaveCalled("https://api.magicthegathering.io/v1/cards*")
+                .WithQueryParams(ID_PARAM);
+        }
+
+        [Fact]
+        public async Task Where_AddMultiverseIdParameter_Success()
+        {
+            const string MULTIPLE_MULTIS = "3|4";
+            const string MULTI_PARAM = "multiverseid";
+
+            _mockRateLimit.Setup(x => x.IsTurnedOn).Returns(false);
+
+            _mockHeaderManager.Setup(x => x.Update(It.IsAny<IReadOnlyNameValueList<string>>()));
+            _mockHeaderManager.Setup(x => x.Get<int>(ResponseHeader.TotalCount)).Returns(2000);
+            _mockHeaderManager.Setup(x => x.Get<int>(ResponseHeader.PageSize)).Returns(1000);
+
+            var rootCardList = new RootCardListDto()
+            {
+                Cards = new List<CardDto> { new CardDto() },
+            };
+
+            using var httpTest = new HttpTest();
+            httpTest.RespondWithJson(rootCardList);
+
+            _mockModelMapper.Setup(x => x.MapCard(It.IsAny<CardDto>())).Returns(new Card());
+
+            var service = new CardService(
+                _mockHeaderManager.Object,
+                _mockModelMapper.Object,
+                ApiVersion.V1,
+                _mockRateLimit.Object);
+
+            // act
+            await service
+                .Where(x => x.MultiverseId, MULTIPLE_MULTIS)
+                .AllAsync();
+
+            // assert
+            httpTest
+                .ShouldHaveCalled("https://api.magicthegathering.io/v1/cards*")
+                .WithQueryParams(MULTI_PARAM);
+        }
+
         [Fact]
         public void Where_DefaultValue_Throws()
         {
@@ -563,6 +644,22 @@ namespace MtgApiManager.Lib.Test.Service
             // act
             // assert
             Assert.Throws<ArgumentNullException>(() => service.Where(_ => null, NAME));
+        }
+
+        [Fact]
+        public async Task Where_AddMultiverseIdNoMock_Success()
+        {
+            const string MULTIPLE_MULTIS = "3|4|5|6";
+
+            var serviceProvider = new MtgServiceProvider();
+            var service = serviceProvider.GetCardService();
+
+            var result = await service
+                .Where(x => x.MultiverseId, MULTIPLE_MULTIS)
+                .AllAsync();
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(4, result.Value.Count);
         }
     }
 }

--- a/src/MtgApiManager.Lib/Service/CardQueryParameter.cs
+++ b/src/MtgApiManager.Lib/Service/CardQueryParameter.cs
@@ -50,6 +50,12 @@ namespace MtgApiManager.Lib.Service
         public string GameFormat { get; set; }
 
         /// <summary>
+        /// Gets or sets the identifier of the card.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        /// <summary>
         /// Gets or sets the language the card is printed in. Use this parameter when searching by foreignName.
         /// </summary>
         [JsonPropertyName("language")]
@@ -72,6 +78,12 @@ namespace MtgApiManager.Lib.Service
         /// </summary>
         [JsonPropertyName("loyalty")]
         public string Loyalty { get; set; }
+
+        /// <summary>
+        /// Gets the multiverse identifier of the card on Wizard’s Gatherer web page. Cards from sets that do not exist on Gatherer will NOT have a multiverse identifier. Sets not on Gatherer are: ATH, ITP, DKM, RQS, DPA and all sets with a 4 letter code that starts with a lowercase 'p’.
+        /// </summary>
+        [JsonPropertyName("multiverseid")]
+        public string MultiverseId { get; set; }
 
         /// <summary>
         /// Gets or sets the card name. For split, double-faced and flip cards, just the name of one side of the card. Basically each ‘sub-card’ has its own record.


### PR DESCRIPTION
Property values `Id` and `MultiverseId` are added to the type `CardQueryParameter`.

The [MTG Api cards endpoint](https://docs.magicthegathering.io/#api_v1cards_list) allow for both an id and multiverseid value to be specified, so adding the properties allow for the `ICardService` to better reflect the source api.

The extra properties may have overlap with the `FindAsync` method. However, one main benefit of the change is that multiple ids or multiverseids can be specified in a single request. As compared to `FindAsync`, only a max of one id or multiverseid can be searched per request.

The following test case is made possible with the addition of the above properties.  Multiple multiverseids can be specified, which also results in receiving multiple cards in a single request.

```csharp
[Fact]
public async Task Where_AddMultiverseIdNoMock_Success()
{
    const string MULTIPLE_MULTIS = "3|4|5|6";

    var serviceProvider = new MtgServiceProvider();
    var service = serviceProvider.GetCardService();

    var result = await service
        .Where(x => x.MultiverseId, MULTIPLE_MULTIS)
        .AllAsync();

    Assert.True(result.IsSuccess);
    Assert.Equal(4, result.Value.Count);
}
```