### PR TITLE
Pass down cancellation token to api requests

### DIFF
--- a/src/MtgApiManager.Lib.Test/Core/RateLimitTest.cs
+++ b/src/MtgApiManager.Lib.Test/Core/RateLimitTest.cs
@@ -16,7 +16,7 @@ namespace MtgApiManager.Lib.Test.Core
             rateLimit.AddApiCall();
 
             // act
-            var result = await rateLimit.Delay(REQUESTS_PER_HOUR);
+            var result = await rateLimit.Delay(REQUESTS_PER_HOUR, default);
 
             Assert.NotEqual(0, result);
         }
@@ -29,7 +29,7 @@ namespace MtgApiManager.Lib.Test.Core
             var rateLimit = new RateLimit(false);
 
             // act
-            var result = await rateLimit.Delay(REQUESTS_PER_HOUR);
+            var result = await rateLimit.Delay(REQUESTS_PER_HOUR, default);
 
             Assert.Equal(0, result);
         }
@@ -43,7 +43,7 @@ namespace MtgApiManager.Lib.Test.Core
             rateLimit.AddApiCall();
 
             // act
-            var result = await rateLimit.Delay(REQUESTS_PER_HOUR);
+            var result = await rateLimit.Delay(REQUESTS_PER_HOUR, default);
 
             Assert.Equal(0, result);
         }
@@ -56,7 +56,7 @@ namespace MtgApiManager.Lib.Test.Core
             var rateLimit = new RateLimit(true);
 
             // act
-            var result = await rateLimit.Delay(REQUESTS_PER_HOUR);
+            var result = await rateLimit.Delay(REQUESTS_PER_HOUR, default);
 
             Assert.Equal(0, result);
         }

--- a/src/MtgApiManager.Lib.Test/Service/ServiceBaseTestObject.cs
+++ b/src/MtgApiManager.Lib.Test/Service/ServiceBaseTestObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Flurl;
 using MtgApiManager.Lib.Core;
@@ -21,14 +22,9 @@ namespace MtgApiManager.Lib.Test.Service
 
         public Url CurrentQueryUrlTestProp => CurrentQueryUrl;
 
-        public override Task<IOperationResult<List<Card>>> AllAsync()
-        {
-            throw new NotImplementedException();
-        }
-
         public Task<RootCardDto> CallWebServiceGetTestMethod(Uri fakeUri)
         {
-            return CallWebServiceGet<RootCardDto>(fakeUri);
+            return CallWebServiceGet<RootCardDto>(fakeUri, default);
         }
 
         public PagingInfo GetPagingInfoTestMethod()

--- a/src/MtgApiManager.Lib.Test/Service/ServiceBaseTests.cs
+++ b/src/MtgApiManager.Lib.Test/Service/ServiceBaseTests.cs
@@ -66,7 +66,7 @@ namespace MtgApiManager.Lib.Test.Service
             var URL = new Uri("http://fake/url");
 
             _mockRateLimit.Setup(x => x.IsTurnedOn).Returns(true);
-            _mockRateLimit.Setup(x => x.Delay(2000)).ReturnsAsync(1);
+            _mockRateLimit.Setup(x => x.Delay(2000, default)).ReturnsAsync(1);
             _mockRateLimit.Setup(x => x.AddApiCall());
 
             var card = new CardDto() { Id = "12345" };
@@ -132,7 +132,7 @@ namespace MtgApiManager.Lib.Test.Service
         }
 
         [Fact]
-        public void GetPagingInfo_Sucess()
+        public void GetPagingInfo_Success()
         {
             // arrange
             _mockHeaderManager.Setup(x => x.Get<int>(ResponseHeader.TotalCount)).Returns(100);

--- a/src/MtgApiManager.Lib/Core/IRateLimit.cs
+++ b/src/MtgApiManager.Lib/Core/IRateLimit.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace MtgApiManager.Lib.Core
 {
@@ -8,7 +9,7 @@ namespace MtgApiManager.Lib.Core
 
         void AddApiCall();
 
-        Task<int> Delay(int requestsPerHour);
+        Task<int> Delay(int requestsPerHour, CancellationToken cancellationToken);
 
         void Reset();
     }

--- a/src/MtgApiManager.Lib/Core/RateLimit.cs
+++ b/src/MtgApiManager.Lib/Core/RateLimit.cs
@@ -39,14 +39,14 @@ namespace MtgApiManager.Lib.Core
             }
         }
 
-        public async Task<int> Delay(int requestsPerHour)
+        public async Task<int> Delay(int requestsPerHour, CancellationToken cancellationToken)
         {
             if (!IsTurnedOn)
             {
                 return 0;
             }
 
-            await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
+            await _semaphoreSlim.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             try
             {
@@ -54,7 +54,7 @@ namespace MtgApiManager.Lib.Core
 
                 if (delayInMilliseconds > 0)
                 {
-                    await Task.Delay(delayInMilliseconds).ConfigureAwait(false);
+                    await Task.Delay(delayInMilliseconds, cancellationToken).ConfigureAwait(false);
                 }
 
                 return delayInMilliseconds;

--- a/src/MtgApiManager.Lib/Service/CardService.cs
+++ b/src/MtgApiManager.Lib/Service/CardService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using MtgApiManager.Lib.Core;
 using MtgApiManager.Lib.Dto;
@@ -24,11 +25,11 @@ namespace MtgApiManager.Lib.Service
         }
 
         /// <inheritdoc />
-        public async override Task<IOperationResult<List<ICard>>> AllAsync()
+        public async Task<IOperationResult<List<ICard>>> AllAsync(CancellationToken cancellationToken = default)
         {
             try
             {
-                var rootCardList = await CallWebServiceGet<RootCardListDto>(CurrentQueryUrl).ConfigureAwait(false);
+                var rootCardList = await CallWebServiceGet<RootCardListDto>(CurrentQueryUrl, cancellationToken).ConfigureAwait(false);
                 ResetCurrentUrl();
 
                 return OperationResult<List<ICard>>.Success(MapCardsList(rootCardList), GetPagingInfo());
@@ -40,15 +41,16 @@ namespace MtgApiManager.Lib.Service
         }
 
         /// <inheritdoc />
-        public Task<IOperationResult<ICard>> FindAsync(int multiverseId) => FindAsync(multiverseId.ToString());
+        public Task<IOperationResult<ICard>> FindAsync(int multiverseId, CancellationToken cancellationToken = default) =>
+            FindAsync(multiverseId.ToString(), cancellationToken);
 
         /// <inheritdoc />
-        public async Task<IOperationResult<ICard>> FindAsync(string id)
+        public async Task<IOperationResult<ICard>> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             try
             {
                 var url = BaseMtgUrl.AppendPathSegments(Version.Name, EndPoint.Name, id);
-                var rootCard = await CallWebServiceGet<RootCardDto>(url).ConfigureAwait(false);
+                var rootCard = await CallWebServiceGet<RootCardDto>(url, cancellationToken).ConfigureAwait(false);
                 var model = ModelMapper.MapCard(rootCard.Card);
 
                 return OperationResult<ICard>.Success(model, GetPagingInfo());
@@ -60,12 +62,12 @@ namespace MtgApiManager.Lib.Service
         }
 
         /// <inheritdoc />
-        public async Task<IOperationResult<List<string>>> GetCardSubTypesAsync()
+        public async Task<IOperationResult<List<string>>> GetCardSubTypesAsync(CancellationToken cancellationToken = default)
         {
             try
             {
                 var url = BaseMtgUrl.AppendPathSegments(Version.Name, ApiEndPoint.SubTypes.Name);
-                var rootTypeList = await CallWebServiceGet<RootCardSubTypeDto>(url).ConfigureAwait(false);
+                var rootTypeList = await CallWebServiceGet<RootCardSubTypeDto>(url, cancellationToken).ConfigureAwait(false);
 
                 return OperationResult<List<string>>.Success(rootTypeList.SubTypes, GetPagingInfo());
             }
@@ -76,12 +78,12 @@ namespace MtgApiManager.Lib.Service
         }
 
         /// <inheritdoc />
-        public async Task<IOperationResult<List<string>>> GetCardSuperTypesAsync()
+        public async Task<IOperationResult<List<string>>> GetCardSuperTypesAsync(CancellationToken cancellationToken = default)
         {
             try
             {
                 var url = BaseMtgUrl.AppendPathSegments(Version.Name, ApiEndPoint.SuperTypes.Name);
-                var rootTypeList = await CallWebServiceGet<RootCardSuperTypeDto>(url).ConfigureAwait(false);
+                var rootTypeList = await CallWebServiceGet<RootCardSuperTypeDto>(url, cancellationToken).ConfigureAwait(false);
 
                 return OperationResult<List<string>>.Success(rootTypeList.SuperTypes, GetPagingInfo());
             }
@@ -92,12 +94,12 @@ namespace MtgApiManager.Lib.Service
         }
 
         /// <inheritdoc />
-        public async Task<IOperationResult<List<string>>> GetCardTypesAsync()
+        public async Task<IOperationResult<List<string>>> GetCardTypesAsync(CancellationToken cancellationToken = default)
         {
             try
             {
                 var url = BaseMtgUrl.AppendPathSegments(Version.Name, ApiEndPoint.Types.Name);
-                var rootTypeList = await CallWebServiceGet<RootCardTypeDto>(url).ConfigureAwait(false);
+                var rootTypeList = await CallWebServiceGet<RootCardTypeDto>(url, cancellationToken).ConfigureAwait(false);
 
                 return OperationResult<List<string>>.Success(rootTypeList.Types, GetPagingInfo());
             }
@@ -108,12 +110,12 @@ namespace MtgApiManager.Lib.Service
         }
 
         /// <inheritdoc />
-        public async Task<IOperationResult<List<string>>> GetFormatsAsync()
+        public async Task<IOperationResult<List<string>>> GetFormatsAsync(CancellationToken cancellationToken = default)
         {
             try
             {
                 var url = BaseMtgUrl.AppendPathSegments(Version.Name, ApiEndPoint.Formats.Name);
-                var rootFormatsList = await CallWebServiceGet<RootCardFormatsDto>(url).ConfigureAwait(false);
+                var rootFormatsList = await CallWebServiceGet<RootCardFormatsDto>(url, cancellationToken).ConfigureAwait(false);
 
                 return OperationResult<List<string>>.Success(rootFormatsList.Formats, GetPagingInfo());
             }

--- a/src/MtgApiManager.Lib/Service/ICardService.cs
+++ b/src/MtgApiManager.Lib/Service/ICardService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using MtgApiManager.Lib.Core;
 using MtgApiManager.Lib.Model;
@@ -13,45 +14,52 @@ namespace MtgApiManager.Lib.Service
         /// <summary>
         /// Gets all the <see cref="Card"/> defined by the query parameters.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A <see cref="IOperationResult{T}"/> representing the result containing all the items.</returns>
-        Task<IOperationResult<List<ICard>>> AllAsync();
+        Task<IOperationResult<List<ICard>>> AllAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Find a specific card by its multi verse identifier.
         /// </summary>
         /// <param name="multiverseId">The multi verse identifier to query for.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A <see cref="IOperationResult{Card}"/> representing the result containing a <see cref="Card"/> or an exception.</returns>
-        Task<IOperationResult<ICard>> FindAsync(int multiverseId);
+        Task<IOperationResult<ICard>> FindAsync(int multiverseId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Find a specific card by its multi verse identifier.
         /// </summary>
         /// <param name="id">The identifier to query for.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A <see cref="IOperationResult{Card}"/> representing the result containing a <see cref="Card"/> or an exception.</returns>
-        Task<IOperationResult<ICard>> FindAsync(string id);
+        Task<IOperationResult<ICard>> FindAsync(string id, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets a list of all the card sub types.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A list of all the card super types.</returns>
-        Task<IOperationResult<List<string>>> GetCardSubTypesAsync();
+        Task<IOperationResult<List<string>>> GetCardSubTypesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets a list of all the card super types.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A list of all the card super types.</returns>
-        Task<IOperationResult<List<string>>> GetCardSuperTypesAsync();
+        Task<IOperationResult<List<string>>> GetCardSuperTypesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets a list of all the card types.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A list of all the card types.</returns>
-        Task<IOperationResult<List<string>>> GetCardTypesAsync();
+        Task<IOperationResult<List<string>>> GetCardTypesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets a list of all game formats.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>A list of all game formats.</returns>
-        Task<IOperationResult<List<string>>> GetFormatsAsync();
+        Task<IOperationResult<List<string>>> GetFormatsAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/MtgApiManager.Lib/Service/ISetService.cs
+++ b/src/MtgApiManager.Lib/Service/ISetService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using MtgApiManager.Lib.Core;
 using MtgApiManager.Lib.Model;
@@ -13,21 +14,24 @@ namespace MtgApiManager.Lib.Service
         /// <summary>
         /// Gets all the <see cref="Set"/> defined by the query parameters.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>An object representing the result containing all the items.</returns>
-        Task<IOperationResult<List<ISet>>> AllAsync();
+        Task<IOperationResult<List<ISet>>> AllAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Find a specific card by its set code.
         /// </summary>
         /// <param name="code">The set code to query for.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>An object representing the result containing a <see cref="Set"/> or an exception.</returns>
-        Task<IOperationResult<ISet>> FindAsync(string code);
+        Task<IOperationResult<ISet>> FindAsync(string code, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///  Generates a booster pack for a specific set asynchronously.
         /// </summary>
         /// <param name="code">The set code to generate a booster for.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
         /// <returns>An object representing the result containing a <see cref="List{Card}"/> or an exception.</returns>
-        Task<IOperationResult<List<ICard>>> GenerateBoosterAsync(string code);
+        Task<IOperationResult<List<ICard>>> GenerateBoosterAsync(string code, CancellationToken cancellationToken = default);
     }
 }

--- a/src/MtgApiManager.Lib/Service/SetService.cs
+++ b/src/MtgApiManager.Lib/Service/SetService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Flurl;
 using MtgApiManager.Lib.Core;
@@ -24,11 +25,11 @@ namespace MtgApiManager.Lib.Service
         }
 
         /// <inheritdoc />
-        public async override Task<IOperationResult<List<ISet>>> AllAsync()
+        public async Task<IOperationResult<List<ISet>>> AllAsync(CancellationToken cancellationToken = default)
         {
             try
             {
-                var rootSetList = await CallWebServiceGet<RootSetListDto>(CurrentQueryUrl).ConfigureAwait(false);
+                var rootSetList = await CallWebServiceGet<RootSetListDto>(CurrentQueryUrl, cancellationToken).ConfigureAwait(false);
                 ResetCurrentUrl();
 
                 return OperationResult<List<ISet>>.Success(MapSetsList(rootSetList), GetPagingInfo());
@@ -40,12 +41,12 @@ namespace MtgApiManager.Lib.Service
         }
 
         /// <inheritdoc />
-        public async Task<IOperationResult<ISet>> FindAsync(string code)
+        public async Task<IOperationResult<ISet>> FindAsync(string code, CancellationToken cancellationToken = default)
         {
             try
             {
                 var url = BaseMtgUrl.AppendPathSegments(Version.Name, EndPoint.Name, code);
-                var rootSet = await CallWebServiceGet<RootSetDto>(url).ConfigureAwait(false);
+                var rootSet = await CallWebServiceGet<RootSetDto>(url, cancellationToken).ConfigureAwait(false);
                 var model = ModelMapper.MapSet(rootSet.Set);
 
                 return OperationResult<ISet>.Success(model, GetPagingInfo());
@@ -57,12 +58,12 @@ namespace MtgApiManager.Lib.Service
         }
 
         /// <inheritdoc />
-        public async Task<IOperationResult<List<ICard>>> GenerateBoosterAsync(string code)
+        public async Task<IOperationResult<List<ICard>>> GenerateBoosterAsync(string code, CancellationToken cancellationToken = default)
         {
             try
             {
                 var url = BaseMtgUrl.AppendPathSegments(Version.Name, EndPoint.Name, code, "booster");
-                var rootCardList = await CallWebServiceGet<RootCardListDto>(url).ConfigureAwait(false);
+                var rootCardList = await CallWebServiceGet<RootCardListDto>(url, cancellationToken).ConfigureAwait(false);
 
                 var cards = rootCardList.Cards
                 .Select(x => ModelMapper.MapCard(x))


### PR DESCRIPTION
Add a [CancellationToken](https://docs.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken?view=net-6.0) to each of the api service requests, which will enable for early Task cancellations and more responsive requests.

The new parameter is also optional, making this change backwards compatible with previous versions.