### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Creating a new service provider used to fetch the different services available.
 ```cs
 IMtgServiceProvider serviceProvider = new MtgServiceProvider();
 ```
-The result of all service calls resturns a generic **IOperationResult** containing the results of the call. It's also important to note that the active query that was added with the Where method will be cleared after a query is performed with the AllAsync method.
+The result of all service calls returns a generic `Task<IOperationResult>` containing the results of the call. It's also important to note that the active query that was added with the [Where()](https://github.com/MagicTheGathering/mtg-sdk-dotnet#filter-cards-via-query-parameters) method will be cleared after a query is performed with the AllAsync method.
 ```cs
 ICardService service = serviceProvider.GetCardService();
-IOperationResult<List<ICard>> result = service.AllAsync();
+IOperationResult<List<ICard>> result = service.AllAsync().Result;
 if (result.IsSuccess)
 {
   var value = result.Value;


### PR DESCRIPTION
Usage section was inaccurate. Service calls return tasks with generic IOperationResult objects that are accessed with Result() method